### PR TITLE
Feature/local learner explainer

### DIFF
--- a/sparkling_lime/discretize.py
+++ b/sparkling_lime/discretize.py
@@ -40,6 +40,7 @@ class BaseDiscretizer(BaseSparkMethods):
         self.stds = {}
         self.mins = {}
         self.maxs = {}
+        self.feature_names = feature_names
         self.random_state = check_random_state(random_state)
         self.categorical_features_names = categorical_feature_names
 
@@ -131,12 +132,13 @@ class BaseDiscretizer(BaseSparkMethods):
         :param data: pyspark.sql.DataFrame
         :return: a pyspark.sql.DataFrame with same dimension, but discretized
         """
+        other_cols = [c for c in data.columns if c not in self.feature_names]
         pipe = Pipeline(stages=list(self.bucketizers.values()))
         discretized = pipe.fit(data).transform(data)
         disc_select = [col(c).alias(c.lstrip("disc_"))
                        for c in discretized.columns if c.startswith("disc_")]
         discretized = discretized.select(
-            *(disc_select + self.categorical_features_names))
+            *(disc_select + self.categorical_features_names + other_cols))
         return discretized
 
     def undiscretize(self, data):

--- a/sparkling_lime/lime_tabular.py
+++ b/sparkling_lime/lime_tabular.py
@@ -1,3 +1,6 @@
+# TODO UPDATE DOCS
+
+
 from sparkling_lime.sparkling_lime_base import BaseSparkMethods
 from sparkling_lime.discretize import BaseDiscretizer, QuartileDiscretizer, \
     DecileDiscretizer

--- a/sparkling_lime/lime_tabular.py
+++ b/sparkling_lime/lime_tabular.py
@@ -1,0 +1,468 @@
+from sparkling_lime.sparkling_lime_base import BaseSparkMethods
+from sparkling_lime.discretize import BaseDiscretizer, QuartileDiscretizer, \
+    DecileDiscretizer
+from sparkling_lime.metrics import HasKernelWidth, HasDistanceMetric
+import numpy as np
+import pyspark.sql.functions as F
+from pyspark.sql.functions import col, sqrt, exp, pow
+from pyspark.sql.types import DoubleType
+from scipy.spatial import distance
+from pyspark.ml import Transformer, UnaryTransformer, Estimator
+from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
+from pyspark.ml.param.shared import HasInputCol, HasOutputCol, HasFeaturesCol, \
+    HasLabelCol, HasNumFeatures, HasSeed, HasParallelism, HasPredictionCol
+from pyspark.ml.param import Param, Params, TypeConverters
+from pyspark import keyword_only
+from pyspark.ml.regression import LinearRegression
+from multiprocessing.pool import ThreadPool
+from pyspark.sql import DataFrame
+import threading
+from pyspark.ml.common import _py2java
+from pyspark.ml.wrapper import JavaParams
+from pyspark.sql import SparkSession
+
+
+def _parallelDatasetsFitTasks(wrapper, est, trains, epm):
+    """
+    Creates a list of callables which can be called from different threads to fit
+    estimators in parallel to multiple training sets (`trains`).
+    Each callable returns an `index` value and the fitted model.
+
+    :param est: Estimator, the estimator to be fit.
+    :param trains: List of DataFrames, (training data set), used for fitting.
+    :param epm: ParamMap to be used during fitting
+    :return: (int, `Estimator`), an index into `trains` and the associated
+    fitted estimator
+    """
+    modelIter = wrapper.fitMultipleDatasets(est, trains, epm)
+
+    def singleTask():
+        index, model = next(modelIter)
+        return index, model
+
+    return [singleTask] * len(trains)
+
+
+def _parallelDatasetsTransformTasks(wrapper, models, datasets):
+    """
+    Creates a list of callables which can be called from different threads to
+    transform multiple datasets by models in parallel.
+    Each callable returns an `index` value as well as the transformed data.
+
+    :param wrapper: Instance of the class containing the transformMultipleDatasets
+       method.
+    :param models: The fitted models to be used to transform teh datasets/
+    :param train: DataFrame, training data set, used for fitting.
+    :return: (int, `pyspark.sql.DataFrame`), an index into `models`/`datasets`
+        and the associated transformed dataset.
+    """
+    if len(models) != len(datasets):
+        raise ValueError("Number of models must equal number of datasets.")
+
+    modelIter = wrapper.transformMultipleDatasets(models, datasets)
+
+    def singleTask():
+        index, transformed = next(modelIter)
+        return index, transformed
+
+    return [singleTask] * len(models)
+
+
+class ParallelTransformer(Params):
+
+    def transformMultipleDatasets(self, transformers, datasets):
+        """
+        Applies transforms each dataset in `datasets` using the associated
+        fitted model in `transformers`
+        :param transformers: List of fitted models to transform the datasets
+        :param datasets: List of datasets to be transformed
+        :return: Thread safe iterable which contains one transformed dataset
+        for each raw dataset. Each call to `next(modelIterator)` will return
+        `(index, dataset)` where data was transfromed using
+        `transformers[index]`. `index` values may not be sequential.
+        """
+
+        def transformSingleDataset(index):
+            model = transformers[index].copy()
+            return model.transform(datasets[index])
+
+        return _TransformMultipleDatasetsIterator(transformSingleDataset,
+                                                  len(transformers))
+
+
+class ReusedEstimator(Params):
+
+    def fitMultipleDatasets(self, est, datasets, paramMap):
+        """
+        Fits a model with a paramMap to each dataset in datasets.
+
+        :param dataset: input datasets, which is an array of
+        :py:class:`pyspark.sql.DataFrame`.
+        :param paramMaps: A param map used for fitting the model
+        :return: Thread safe iterable which contains one model for each dataset.
+            Each call to `next(modelIterator)` will return `(index, model)`
+            where model was fit using `datasets[index]`.
+            `index` values may not be sequential.
+        """
+        estimator = est.copy()
+
+        def fitSingleModel(index):
+            return estimator.fit(datasets[index], paramMap)
+
+        return _FitMultipleDatasetsIterator(fitSingleModel, len(datasets))
+
+
+class _TransformMultipleDatasetsIterator(object):
+    """
+    Used by default implementation of Estimator.fitMultiple to produce models in a thread safe
+    iterator. This class handles the simple case of fitMultiple where each param map should be
+    fit independently.
+
+    :param fitSingleModel: Function: (int => Model) which fits an estimator to a dataset.
+        `fitSingleModel` may be called up to `numModels` times, with a unique index each time.
+        Each call to `fitSingleModel` with an index should return the Model associated with
+        that index.
+    :param numModel: Number of models this iterator should produce.
+
+    See Estimator.fitMultiple for more info.
+    """
+    def __init__(self, transformSingleModel, numModels):
+        """
+
+        """
+        self.transformSingleModel = transformSingleModel
+        self.numModel = numModels
+        self.counter = 0
+        self.lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self.lock:
+            index = self.counter
+            if index >= self.numModel:
+                raise StopIteration("No models remaining.")
+            self.counter += 1
+        return index, self.transformSingleModel(index)
+
+    def next(self):
+        """For python2 compatibility."""
+        return self.__next__()
+
+
+class _FitMultipleDatasetsIterator(object):
+    """
+    Used by default implementation of Estimator.fitMultiple to produce models in a thread safe
+    iterator. This class handles the simple case of fitMultiple where each param map should be
+    fit independently.
+
+    :param fitSingleModel: Function: (int => Model) which fits an estimator to a dataset.
+        `fitSingleModel` may be called up to `numModels` times, with a unique index each time.
+        Each call to `fitSingleModel` with an index should return the Model associated with
+        that index.
+    :param numModel: Number of models this iterator should produce.
+
+    See Estimator.fitMultiple for more info.
+    """
+    def __init__(self, fitSingleModel, numModels):
+        """
+
+        """
+        self.fitSingleModel = fitSingleModel
+        self.numModel = numModels
+        self.counter = 0
+        self.lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self.lock:
+            index = self.counter
+            if index >= self.numModel:
+                raise StopIteration("No models remaining.")
+            self.counter += 1
+        return index, self.fitSingleModel(index)
+
+    def next(self):
+        """For python2 compatibility."""
+        return self.__next__()
+
+
+class LocalLinearLearnerParams(Params):
+    estimator = Param(Params._dummy(), "estimator",
+                      "Regressor to use in explanation. Defaults to ridge"
+                      " regression.")
+    estimatorParamMap = Param(Params._dummy(), "estimatorParamMap", "")  # TODO
+
+    def setEstimator(self, value):
+        """
+        Sets the value of :py:attr:`localEstimator`
+        """
+        return self._set(estimator=value)
+
+    def getEstimator(self):
+        """
+        Gets the value of localEstimator or its default value.
+        """
+        return self.getOrDefault(self.estimator)
+
+    def setEstimatorParamMap(self, value):
+        """
+        Sets the value of :py:attr:`estimatorParamMap`.
+        """
+        return self._set(estimatorParamMaps=value)
+
+    def getEstimatorParamMap(self):
+        """
+        Gets the value of estimatorParamMap or its default value.
+        """
+        return self.getOrDefault(self.estimatorParamMap)
+
+
+class LocalLinearLearner(HasFeaturesCol, HasLabelCol, HasSeed,
+                         Estimator, ReusedEstimator, LocalLinearLearnerParams,
+                         DefaultParamsReadable, DefaultParamsWritable,
+                         HasParallelism):
+    """
+    # NOTE: Need pre-weighted and distance-calculated data (is this okay????)
+    """
+
+    @keyword_only
+    def __init__(self, estimator=None, featuresCol="neighborhood",
+                 labelCol="localLabel", parallelism=1, seed=None):
+        super(LocalLinearLearner, self).__init__()
+        self._setDefault(featuresCol="neighborhood", labelCol="localLabel",
+                         parallelism=1,
+                         localEstimator=LinearRegression(
+                             regParam=1.0, elasticNetParam=0.0,
+                             featuresCol=featuresCol, labelCol=labelCol))
+        kwargs = self._input_kwargs
+        self.setParams(**kwargs)
+
+    @keyword_only
+    def setParams(self, estimator=None, labelCol="localLabel",
+                  featuresCol="neighborhood", parallelism=1):
+        """
+        Sets params for this KernelWeight transformer.
+        """
+        kwargs = self._input_kwargs
+        return self._set(**kwargs)
+
+    def _fit(self, datasets):
+        est = self.getOrDefault(self.localEstimator)
+        epm = est.extractParamMap()
+        if isinstance(datasets, DataFrame):
+            datasets = [datasets]
+        else:
+            datasets = list(datasets)
+        numModels = len(datasets)
+        pool = ThreadPool(processes=min(self.getParallelism(), numModels))
+        models = [0] * len(datasets)
+        tasks = _parallelDatasetsFitTasks(self, est, datasets, epm)
+        for j, model in pool.imap_unordered(lambda f: f(), tasks):
+            models[j] = model
+            datasets[j].unpersist()
+        llm = self._copyValues(LocalLinearLearnerModel(fittedModels=models))
+        return llm
+
+
+class LocalLinearLearnerModel(HasFeaturesCol, HasLabelCol, HasPredictionCol,
+                              HasParallelism, HasSeed, LocalLinearLearnerParams,
+                              Transformer, ParallelTransformer):
+    fittedModels = Param(Params._dummy(), "fittedModels",
+                         "List of models fitted to datasets.")
+
+    def setFittedModels(self, value):
+        """
+        Sets the value of :py:attr:`fittedModels`
+        """
+        return self._set(fittedModels=value)
+
+    def getFittedModels(self):
+        """
+        Gets the value of fittedModels or the default.
+        """
+        return self.getOrDefault(self.fittedModels)
+
+    @keyword_only
+    def __init__(self, globalEstimator=None,
+                 featuresCol="features", labelCol="label",
+                 localLabelCol="localLabel", parallelism=1,
+                 seed=None, fittedModels=()):
+        super().__init__()
+        self._setDefault(featuresCol="features",
+                         labelCol="label", localLabelCol="localLabel",
+                         parallelism=1)
+        kwargs = self._input_kwargs
+        self.setParams(**kwargs)
+
+    @keyword_only
+    def setParams(self, globalEstimator=None,
+                  labelCol="label", localLabelCol="localLabel",
+                  featuresCol="features",
+                  explainLabels=(1,), fittedModels=()):
+        """
+        Sets params for this KernelWeight transformer.
+        """
+        kwargs = self._input_kwargs
+        return self._set(**kwargs)
+
+    def _transform(self, datasets):
+        models = self.getOrDefault(self.fittedModels)
+        if isinstance(datasets, DataFrame):
+            datasets = [datasets]
+        else:
+            datasets = list(datasets)
+        numModels = len(models)
+
+        if numModels != len(datasets):
+            raise ValueError("Number of models did not match number of datasets"
+                             " to transform.")
+        pool = ThreadPool(processes=min(self.getParallelism(), numModels))
+        transformed_datasets = [0] * len(datasets)
+        tasks = _parallelDatasetsTransformTasks(self, models, datasets)
+        for j, transformed_data in pool.imap_unordered(lambda f: f(), tasks):
+            transformed_datasets[j] = transformed_data
+            datasets[j].unpersist()
+        return transformed_datasets
+#
+#
+# class LimeTabularExplainer(BaseSparkMethods):
+#     def __init__(self,
+#                  training_data,
+#                  mode="classification",
+#                  training_labels=None,
+#                  feature_names=None,
+#                  categorical_features=None,
+#                  categorical_names=None,
+#                  kernel_width=None,
+#                  verbose=False,
+#                  class_names=None,
+#                  feature_selection='auto',
+#                  discretize_continuous=True,
+#                  discretizer='quartile',
+#                  sample_around_instance=False,
+#                  random_state=None):
+#         """
+#
+#         :param training_data:
+#         :param mode:
+#         :param training_labels:
+#         :param feature_names:
+#         :param categorical_features: Names of categorical feature columns
+#         :param categorical_names: -- basically the stringindexer map #TODO
+#         :param kernel_width:
+#         :param verbose:
+#         :param class_names:
+#         :param feature_selection:
+#         :param discretize_continuous:
+#         :param discretizer:
+#         :param sample_around_instance:
+#         :param random_state:
+#         """
+#         super().__init__()
+#         # TODO
+#         # self.random_state = check_random_state(random_state)
+#         self.mode = mode
+#         self.categorical_features = categorical_features or []
+#         self.categorical_names = categorical_names or {}
+#         self.sample_around_instance = sample_around_instance
+#         self.feature_names = feature_names or []
+#         self.discretizer = None
+#         if discretize_continuous:
+#             if discretizer == 'quartile':
+#                 self.discretizer = QuartileDiscretizer(
+#                         training_data, self.categorical_features,
+#                         self.feature_names, labels=training_labels)
+#             elif discretizer == 'decile':
+#                 self.discretizer = DecileDiscretizer(
+#                         training_data, self.categorical_features,
+#                         self.feature_names, labels=training_labels)
+#             elif isinstance(discretizer, BaseDiscretizer):
+#                 self.discretizer = discretizer
+#             else:
+#                 raise ValueError(("Discretizer must be 'quartile', 'decile',",
+#                                   " or a BaseDiscretizer instance"))
+#
+#         self.feature_selection = feature_selection
+#         self.scaler = None
+#         self.class_names = class_names
+#         self.scaler.fit(training_data)  # TODO
+#         self.feature_values = {}
+#         self.feature_frequencies = {}
+#
+#
+# class ExplainerParams(Params):
+#     localEstimator = Param(Params._dummy(), "localEstimator",
+#                            "Regressor to use in explanation. Defaults to ridge"
+#                            " regression.")
+#     globalEstimator = Param(Params._dummy(), "globalEstimator",
+#                             "Fitted model to generate global predictions on "
+#                             "perturbed dataset.")
+#     explainLabels = Param(Params._dummy(), "explainLabels",
+#                           "Iterable of (numerical) labels to be explained.",
+#                           typeConverter=TypeConverters.toListInt)
+#     discretizer = Param(Params._dummy(), "discretizer",
+#                         ("The discretizer. Supported discretizers are "
+#                          "'QuartileDiscretizer', 'DecileDiscretizer' or None."))
+#     weightCol = Param(Params._dummy(), "weightCol",
+#                       "Name of column with weights.",
+#                       typeConverter=TypeConverters.toString)
+#     distanceCol = Param(Params._dummy(), "distanceCol",
+#                         "Name of column with feature distances.",
+#                         typeConverter=TypeConverters.toString)
+#     neighborhoodCol = Param(Params._dummy(), "neighborhoodCol",
+#                             "Name of column with neighborhood of values "
+#                             "sampled around a mean or feature value according "
+#                             "to the feature's statistics. Needs to be an array "
+#                             "of named structs (inverse, binary).")
+#     originalFeaturesCol = Param(Params._dummy(), "originalFeatureCol",
+#                                 "")  # TODO
+#     localLabelCol = Param(Params._dummy(), "localLabelCol", "")  # TODO
+#     estimatorParamMap = Param(Params._dummy(), "estimatorParamMap", "")  # TODO
+#
+#     def setLocalEstimator(self, value):
+#         """
+#         Sets the value of :py:attr:`localEstimator`
+#         """
+#         return self._set(localEstimator=value)
+#
+#     def getLocalEstimator(self):
+#         """
+#         Gets the value of localEstimator or its default value.
+#         """
+#         return self.getOrDefault(self.localEstimator)
+#
+#     def setNeighborhoodCol(self, value):
+#         """
+#         Sets the value of :py:attr: `neighborhoodCol`
+#         """
+#         return self._set(neighborhoodCol=value)
+#
+#     def getNeighborhoodCol(self):
+#         """
+#         Gets the value of neighborhoodCol or its default value.
+#         """
+#         return self.getOrDefault(self.neighborhoodCol)
+#
+#     def setEstimatorParamMap(self, value):
+#         """
+#         Sets the value of :py:attr:`estimatorParamMap`.
+#         """
+#         return self._set(estimatorParamMaps=value)
+#
+#     def getEstimatorParamMap(self):
+#         """
+#         Gets the value of estimatorParamMap or its default value.
+#         """
+#         return self.getOrDefault(self.estimatorParamMap)
+
+
+
+# Need to generate the perturbed dataset
+# Then add the distances
+# Then add the weights
+# Then train a linear model
+# Then transform and score

--- a/sparkling_lime/metrics.py
+++ b/sparkling_lime/metrics.py
@@ -545,23 +545,6 @@ class NeighborhoodGenerator(Transformer, HasInputCols,
         distribution, and making a binary feature that is 1 when the value
         is the same as the instance being explained.
 
-<<<<<<< HEAD
-        The neighborhood is an array of structs with the following schema:
-
-        Output schema:
-            original dataset + for each feature column:
-
-        root
-         |-- <outputCol>: array (nullable = true)
-         |    |-- element: struct (containsNull = false)
-         |    |    |-- inverse: double (nullable = false)
-         |    |    |-- binary: double (nullable = false)
-
-        For continuous variables, the 'binary' element is the same as the
-        'inverse' element (since it is only relevant for categoical variables).
-
-=======
->>>>>>> master
         :param dataset: `pyspark.sql.DataFrame` of features in wide format
         (one feature per column)
         :return: Dataset with original + perturbed features in wide format

--- a/sparkling_lime/metrics.py
+++ b/sparkling_lime/metrics.py
@@ -195,8 +195,10 @@ class KernelWeight(HasKernelWidth, HasInputCol, HasOutputCol, Transformer,
             sqrt(exp(-(pow(col(inputCol), 2)) / kernelWidth ** 2)))
 
 
-class NeighborhoodGenerator(HasInputCols, HasOutputCol, HasSeed, Transformer,
-                            DefaultParamsWritable, DefaultParamsReadable):
+class NeighborhoodGeneratorParams(Params):
+    """
+    Private mixin class for tracking params for NeighborhoodGenerator
+    """
     neighborhoodSize = Param(Params._dummy(), "neighborhoodSize",
                              ("The size of the neighborhood to generate; the  "
                               "number of perturbed samples to generate."),
@@ -205,7 +207,7 @@ class NeighborhoodGenerator(HasInputCols, HasOutputCol, HasSeed, Transformer,
                         ("A fitted QuartileDiscretizer or DecileDiscretizer "
                          "(optional)"))
     format = Param(Params._dummy(), "format",
-                   ("The format to use ('wide'/'narrow'. If 'narrow', the "
+                   ("The format to use ('wide'/'narrow'). If 'narrow', the "
                     "neighborhood will be output as a single 2darray column "
                     "`outputCol` of size [neighborhoodSize][i], where `i` is "
                     "the number of columns in the `inputCols` list. If "
@@ -219,6 +221,63 @@ class NeighborhoodGenerator(HasInputCols, HasOutputCol, HasSeed, Transformer,
                                   " the normal is centered on the mean of the"
                                   " feature data."),
                                  typeConverter=TypeConverters.toBoolean)
+
+    @keyword_only
+    def __init__(self):
+        super(NeighborhoodGeneratorParams, self).__init__()
+
+    def setNeighborhoodSize(self, value):
+        """
+        Sets the value of :py:attr:neighborhoodSize
+        """
+        return self._set(neighborhoodSize=value)
+
+    def getNeighborhoodSize(self):
+        """
+        Returns the value of neighborhoodSize or the default value.
+        """
+        return self.getOrDefault(self.neighborhoodSize)
+
+    def setDiscretizer(self, value):
+        """
+        Sets the value of :py:attr:discretizer
+        """
+        return self._set(discretizer=value)
+
+    def getDiscretizer(self):
+        """
+        Returns the value of discretizer or the default value.
+        """
+        return self.getOrDefault(self.discretizer)
+
+    def setFormat(self, value):
+        """
+        Sets the value of :py:attr:format
+        """
+        return self._set(format=value)
+
+    def getFormat(self):
+        """
+        Returns the value of format or the default value.
+        """
+        return self.getOrDefault(self.format)
+
+    def setSampleAroundInstance(self, value):
+        """
+        Sets the value of :py:attr:sampleAroundInstance
+        """
+        return self._set(sampleAroundInstance=value)
+
+    def getSampleAroundInstance(self):
+        """
+        Returns the value of sampleAroundInstance or the default value.
+        """
+        return self.getOrDefault(self.sampleAroundInstance)
+
+
+class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
+                            HasOutputCol, HasSeed, Transformer,
+                            DefaultParamsWritable, DefaultParamsReadable):
 
     @keyword_only
     def __init__(self, inputCols=None, outputCol=None, neighborhoodSize=5000,
@@ -237,54 +296,6 @@ class NeighborhoodGenerator(HasInputCols, HasOutputCol, HasSeed, Transformer,
         """
         kwargs = self._input_kwargs
         return self._set(**kwargs)
-
-    def setNeighborhoodSize(self, value):
-        """
-        Sets the value of :py:attr:neighborhoodSize
-        """
-        return self._set(neighborhoodSize=value)
-
-    def getNeighborhoodSize(self):
-        """
-        Returns the value of neighborhoodSize or the default value.
-        """
-        return self._getOrDefault(self.neighborhoodSize)
-
-    def setDiscretizer(self, value):
-        """
-        Sets the value of :py:attr:discretizer
-        """
-        return self._set(discretizer=value)
-
-    def getDiscretizer(self):
-        """
-        Returns the value of discretizer or the default value.
-        """
-        return self._getOrDefault(self.discretizer)
-
-    def setFormat(self, value):
-        """
-        Sets the value of :py:attr:format
-        """
-        return self._set(format=value)
-
-    def getFormat(self):
-        """
-        Returns the value of format or the default value.
-        """
-        return self._getOrDefault(self.format)
-
-    def setSampleAroundInstance(self, value):
-        """
-        Sets the value of :py:attr:sampleAroundInstance
-        """
-        return self._set(sampleAroundInstance=value)
-
-    def getSampleAroundInstance(self):
-        """
-        Returns the value of sampleAroundInstance or the default value.
-        """
-        return self._getOrDefault(self.sampleAroundInstance)
 
     @staticmethod
     def _make_zeroes(x, y, format):

--- a/sparkling_lime/metrics.py
+++ b/sparkling_lime/metrics.py
@@ -6,21 +6,70 @@ from pyspark.sql.types import DoubleType
 from scipy.spatial import distance
 from pyspark.ml import Transformer, UnaryTransformer
 from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
-from pyspark.ml.param.shared import HasInputCol, HasOutputCol
+from pyspark.ml.param.shared import HasInputCols, HasInputCol, HasOutputCol, HasSeed
 from pyspark.ml.linalg import VectorUDT
 from pyspark.ml.param import Param, Params, TypeConverters
 from pyspark import keyword_only
 
 
-class PairwiseDistance(UnaryTransformer, DefaultParamsReadable,
-                       DefaultParamsWritable):
+class HasDistanceMetric(Params):
+    """
+    Mixin for param distanceMetric: pairwise distance metric
+    """
+    validDistanceMetrics = ["euclidean"]
+    distanceMetric = Param(Params._dummy(), "distanceMetric",
+                   ("The distance metric. Supported distanceMetrics include: {}"
+                    .format(",".join(validDistanceMetrics))),
+                   typeConverter=TypeConverters.toString)
+    _distance_fns = {"euclidean": distance.euclidean}
+
+    def __init__(self):
+        super(HasDistanceMetric, self).__init__()
+        self._setDefault(distanceMetric="euclidean")
+
+    def setDistanceMetric(self, value):
+        """
+        Sets the value of :py:attr:`distanceMetric`.
+        """
+        self._set(distanceMetric=value)
+
+    def getDistanceMetric(self):
+        """
+        Gets the value of distanceMetric or its default value.
+        """
+        return self.getOrDefault(self.distanceMetric)
+
+
+class HasKernelWidth(Params):
+    """
+    Mixin for param kernelWidth: kernel width
+    """
+    kernelWidth = Param(Params._dummy(), "kernelWidth",
+                        "Kernel width to use in the kernel function.",
+                        typeConverter=TypeConverters.toFloat)
+
+    def __init__(self):
+        super(HasKernelWidth, self).__init__()
+
+    def setKernelWidth(self, value):
+        """
+        Sets the value of :py:attr:`kernelWidth`
+        """
+        return self._set(kernelWidth=value)
+
+    def getKernelWidth(self):
+        """
+        Get the value of kernelWidth or its default value.
+        """
+        return self.getOrDefault(self.kernelWidth)
+
+
+class PairwiseDistance(HasDistanceMetric, UnaryTransformer,
+                       DefaultParamsReadable, DefaultParamsWritable):
     """
     Calculates pairwise distances between a feature column and a provided
      vector of features, and outputs the distances to a column.
     """
-
-    validMetrics = ["euclidean"]
-
     rowVector = Param(Params._dummy(), "rowVector",
                       "The denseVector of features by which the values of the"
                       " dataset are compared to calculate pairwise distances."
@@ -29,24 +78,17 @@ class PairwiseDistance(UnaryTransformer, DefaultParamsReadable,
                       " the distance from second to first.",
                       typeConverter=TypeConverters.toVector)
 
-    metric = Param(Params._dummy(), "metric",
-                   ("The distance metric. Supported metrics include: {}"
-                    .format(",".join(validMetrics))),
-                   typeConverter=TypeConverters.toString)
-
-    _distance_fns = {"euclidean": distance.euclidean}
-
     @keyword_only
     def __init__(self, rowVector=None, inputCol=None, outputCol=None,
-                 metric="euclidean"):
+                 distanceMetric="euclidean"):
         super(PairwiseDistance, self).__init__()
-        self._setDefault(metric="euclidean", rowVector=None)
+        self._setDefault(distanceMetric="euclidean", rowVector=None)
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
 
     @keyword_only
     def setParams(self, rowVector=None, inputCol="features",
-                  outputCol="distances", metric="euclidean"):
+                  outputCol="distances", distanceMetric="euclidean"):
         """
         Sets params for this PairwiseEuclideanDistance transformer.
         """
@@ -64,18 +106,6 @@ class PairwiseDistance(UnaryTransformer, DefaultParamsReadable,
         Sets the value for 'rowVector' param.
         """
         self._set(rowVector=rowVector)
-
-    def getMetric(self):
-        """
-        Gets the value for 'metric' param, or the default.
-        """
-        return self.getOrDefault(self.metric)
-
-    def setMetric(self, metric):
-        """
-        Sets the value for 'metric' param.
-        """
-        self._set(metric=metric)
 
     def validateInputType(self, inputType):
         """
@@ -116,7 +146,7 @@ class PairwiseDistance(UnaryTransformer, DefaultParamsReadable,
         rows of features based on the given distance metric.
         """
         rowVector = self.getRowVector()
-        metric = self.getMetric()
+        metric = self.getDistanceMetric()
         distance_fn = self._distance_fns[metric]
         if rowVector:
             return lambda x: distance_fn(x, rowVector)
@@ -124,14 +154,11 @@ class PairwiseDistance(UnaryTransformer, DefaultParamsReadable,
             return lambda x: distance_fn(x[1], x[0])
 
 
-class KernelWeight(HasInputCol, HasOutputCol, Transformer,
+class KernelWeight(HasKernelWidth, HasInputCol, HasOutputCol, Transformer,
                    DefaultParamsReadable, DefaultParamsWritable):
     """
     Transforms a column of distances into a column of proximity values.
     """
-    kernelWidth = Param(Params._dummy(), "kernelWidth",
-                        "Kernel width to use in the kernel function.",
-                        typeConverter=TypeConverters.toFloat)
 
     @keyword_only
     def __init__(self, kernelWidth=None, inputCol=None, outputCol=None):
@@ -148,18 +175,6 @@ class KernelWeight(HasInputCol, HasOutputCol, Transformer,
         kwargs = self._input_kwargs
         return self._set(**kwargs)
 
-    def getKernelWidth(self):
-        """
-        Get the value for 'kernelWidth' param, or the default.
-        """
-        return self.getOrDefault(self.kernelWidth)
-
-    def setRowVector(self, kernelWidth):
-        """
-        Set the value for 'rowVector' param.
-        """
-        self._set(kernelWidth=kernelWidth)
-
     def _transform(self, dataset):
         """
         Transforms the input dataset.
@@ -174,3 +189,5 @@ class KernelWeight(HasInputCol, HasOutputCol, Transformer,
         return dataset.withColumn(
             outputCol,
             sqrt(exp(-(pow(col(inputCol), 2)) / kernelWidth ** 2)))
+
+

--- a/sparkling_lime/metrics.py
+++ b/sparkling_lime/metrics.py
@@ -421,8 +421,8 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
             instead of the mean. Only relevant if a value for `mean` is not
             provided.
         :return: `pyspark.sql.Column` of centered and scaled normal
-            distribution, in 1 column if "narrow" format, and in `y` columns
-            in "wide" format (named numerically from [0,`y`-1])
+            distribution, in `y` columns in "wide" format
+            (named numerically from [0,`y`-1])
         """
         if mean:
             center = mean
@@ -438,22 +438,25 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
         # If x=3 & y=2,
         #    return two columns: [n1*s1 + m1, n2*s1+m1, n3*s1*m1]
         #                      & [n1`*s2 + m2, n2`*s2 + m2, n3`*s2+m2]
-            return [F.array(
-                        [randn * scaler + val
-                            for randn, scaler, val
-                            in zip(
-                                [F.randn(seed=seed) for i in range(x)],
-                                [scale[col_idx]]*x,
-                                [center[col_idx]]*x)
-                         ]
-                    )
-                    for col_idx in range(y)]
+        return [F.array(
+                    [randn * scaler + val
+                        for randn, scaler, val
+                        in zip(
+                            [F.randn(seed=seed) for i in range(x)],
+                            [scale[col_idx]]*x,
+                            [center[col_idx]]*x)
+                     ]
+                )
+                for col_idx in range(y)]
 
-    def _get_scale_statistics(self, dataset):
+    def _get_scale_statistics(self, dataset, subset=()):
         """
         Gets the relative scaling factor and means of each feature.
         """
-        ic = self.getOrDefault(self.inputCols)
+        if subset:
+            ic = subset
+        else:
+            ic = self.getOrDefault(self.inputCols)
         assembler = VectorAssembler(inputCols=ic, outputCol="features")
         assembled_data = assembler.transform(dataset)
         scaler = StandardScaler(inputCol="features", outputCol="scaled")
@@ -481,6 +484,40 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
             feature_freqs.update({c: value_rates})
         return feature_freqs
 
+    def _undiscretize_helper(self, dataset, subset, orig_col, discretizer):
+        """
+        Format the dataset so that it can be undiscretized, then undiscretize
+        the variable.
+        :param dataset: pyspark.sql.DataFrame
+        :param subset: Name of the column to undiscretize
+        :param orig_col: Name of the original column that the subset column was
+            created from (original feature name)
+        :param discretizer: A fitted Discretizer class (Quantile/Decile)
+        :returns: pyspark.sql.DataFrame with the sampled `subset` column
+            undiscretized. Also removes the "binary" element of the struct and
+            replaces it with the undiscretized value (since it's no longer
+            relevant as a continuous variable).
+        """
+        other_cols = [c for c in dataset.columns if c != subset]
+        id_col = str(hash("_undiscretize_helper"))
+        df = dataset.withColumn(id_col, F.monotonically_increasing_id())
+        df.cache()    # Force compute of id
+        df = df.withColumn(subset, F.explode(subset))\
+            .withColumn("inverse", col(subset)["inverse"])\
+            .withColumn("binary", col(subset)["binary"])
+        # Get statistics from the source column (original feature data)
+        means, stds, mins, maxs = (discretizer.means[orig_col],
+                                   discretizer.stds[orig_col],
+                                   discretizer.mins[orig_col],
+                                   discretizer.maxs[orig_col])
+        df = discretizer.static_undiscretize(dataset, ["inverse"], means, stds,
+                                             mins, maxs, self.getSeed())
+        df = df.groupBy(id_col, *other_cols)\
+            .agg(F.collect_list(F.struct(col("inverse"),
+                                         col("inverse").alias("binary")))    # Only kept to avoid KeyError
+                 .alias(subset))
+        return df
+
     def _transform(self, dataset):
         # Configure column names and save a map of inputs => outputs
         ic = self.getOrDefault(self.inputCols)
@@ -493,6 +530,7 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
         else:
             binary_output_cols = ["binary_"+c for c in ic]
         inverse_col_map = dict(zip(ic, inverse_output_cols))
+        inverse_to_orig_col_map = dict(zip(inverse_output_cols, ic))
         binary_col_map = dict(zip(ic, binary_output_cols))
 
         # Get necessary vars and pull required stats (freqs, scales, means)
@@ -501,7 +539,6 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
         num_feats = len(ic)
         seed = self.getOrDefault(self.seed)
         sample_around_instance = self.getOrDefault(self.sampleAroundInstance)
-        scales, means = self._get_scale_statistics(dataset)
         if discretizer:
             categorical_cols = ic
             continuous_cols = None
@@ -510,35 +547,29 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
             continuous_cols = [c for c in ic if c not in categorical_cols]
         feature_freqs = self._get_feature_freqs(dataset,
                                                 subset=categorical_cols)
-
-        # Generate a 2d array of zeros or samples from normal distribution,
-        #   size=[numSamples][numFeatures]
-        if discretizer:
-            pass
-        #     wide_cols = self._make_zeroes(num_samples, num_feats,
-        #                                   format="wide")
-        #     wide_cols_named = [c.alias("{}_{}".format(oc, n))
-        #                        for c, n in zip(wide_cols, range(num_feats))]
-        #     dataset = dataset.select("*", *wide_cols_named)
-        else:
+        for c in categorical_cols:
+            # Randomly sample according to categorical value frequency
+            dataset = self._make_random_choices_and_binarize(
+                    dataset, c,  num_samples, feature_freqs[c],
+                    inverse_col_map[c])
+            # Undiscretize if the column is a discretized continuous feature
+            if discretizer:
+                if c in discretizer.to_discretize:
+                    dataset = self._undiscretize_helper(
+                        dataset, c, inverse_to_orig_col_map[c], discretizer)
+        if continuous_cols:
+            scales, means = self._get_scale_statistics(dataset,
+                                                       subset=continuous_cols)
             if sample_around_instance:     # Center around feature mean or value
-                cols = [col(c) for c in ic]
+                cols = [col(c) for c in continuous_cols]
                 means = None
             else:
                 cols = None
             wide_cols = self._make_normals(num_samples, num_feats,
                                            scale=scales, mean=means,
                                            cols=cols, seed=seed)
-            # Duplicate them to be the base for binary and inverse outputs
-            wide_cols_named = [c.alias(i) for c, i
-                               in zip(wide_cols, inverse_output_cols)] + \
-                [c.alias(i) for c, i in zip(wide_cols, binary_output_cols)]
-
+            wide_cols_named = [F.struct(c.alias("inverse"), c.alias("binary"))
+                               .alias(inverse_col_map[c]) for c in wide_cols]
             dataset = dataset.select("*", *wide_cols_named)
-        # Process categorical/discretized features
-        for c in categorical_cols:
-            dataset = self._make_random_choices_and_binarize(
-                dataset, c,  num_samples, feature_freqs[c], inverse_col_map[c]
-            )
 
         return dataset

--- a/sparkling_lime/metrics.py
+++ b/sparkling_lime/metrics.py
@@ -373,8 +373,8 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
         :return: dataset with output_col with an array of num_samples structs
         of value choice + binary class (is same/diff)
         """
-        binary_output_col = "binary_" + input_col
-        inverse_output_col = "inverse_" + input_col
+        binary_output_col = "binary"
+        inverse_output_col = "inverse"
 
         random_state = np.random.RandomState(seed=seed)
         ordered_rates = [(k, v) for k, v in feature_rate_dict.items()]    # For safe iteration
@@ -385,19 +385,19 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
         dataset = dataset.withColumn(
                 inverse_output_col,
                 F.array(
-                    [lit(random_state.choice(
+                    [lit(float(random_state.choice(
                         [r[0] for r in ordered_rates],
                         size=1,
                         replace=True,
-                        p=[r[1] for r in ordered_rates])[0])
-                     for i in num_samples]
+                        p=[r[1] for r in ordered_rates])[0]))
+                     for i in range(num_samples)]
                 ))
         # Hard to iterate over array to make binarized column, so explode instead
         dataset = dataset.withColumn(inverse_output_col,
                                      F.explode(inverse_output_col))
         dataset = dataset.withColumn(
             binary_output_col,
-            F.when(col(inverse_output_col == col(input_col)), 1).otherwise(0))
+            F.when(col(inverse_output_col) == col(input_col), 1).otherwise(0))
         dataset = dataset.withColumn(
              output_col,
              F.struct(inverse_output_col, binary_output_col))
@@ -408,7 +408,7 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
         return dataset
 
     @staticmethod
-    def _make_normals(x, y, format, scale, mean=(), cols=None, seed=None):
+    def _make_normals(x, y, scale, mean=(), cols=None, seed=None):
         """
         Make a column of 2darray of zeros[x][y]
         :param x: number of rows
@@ -429,37 +429,25 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
         else:
             center = cols
 
-        # Generate [x]*[y] samples of normal distribution, scale each value by
-        #   scaling factor and then add the center value
+        # For `y` columns, generate `x` samples of normal distribution, scale
+        #   each value by scaling factor and then add the center value.
         # For example, let `n` be a random sample from normal distribution,
         #   `s` be the scaling factor for a feature, and `m` the mean for the
         #    feature:
-        #       return (n*s) + m, for all s in scale and m in mean.
-        # So if x=2 and y=2:
-        #    return [[n1*s1 + m1, n2*s2 + m2], [n1`*s1 + m1, n2`*s2 + m2]]
-        if format == "narrow":
-            return F.array(
-                *[F.array(
-                    [randn * scaler + val
-                     for randn, scaler, val
-                     in zip(
-                         [F.randn(seed=seed) for i in range(y)], scale, center)
-                     ])
-                  for i in range(x)])
-        # Similar to above, but instead of nested 2darray, what would be the
-        # nesting structure is distributed over columns
-        # If use above example, x=2 & y=2,
-        #    return two columns: [n1*s1 + m1, n2*s2+m2]
-        #                      & [n1`*s1 + m1, n2`*s2 + m1]
-        elif format == "wide":
+        #       return (n*s) + m
+        # If x=3 & y=2,
+        #    return two columns: [n1*s1 + m1, n2*s1+m1, n3*s1*m1]
+        #                      & [n1`*s2 + m2, n2`*s2 + m2, n3`*s2+m2]
             return [F.array(
                         [randn * scaler + val
                             for randn, scaler, val
                             in zip(
-                                [F.randn(seed=seed) for i in range(x)], scale, center)
+                                [F.randn(seed=seed) for i in range(x)],
+                                [scale[col_idx]]*x,
+                                [center[col_idx]]*x)
                          ]
                     )
-                    for i in range(y)]
+                    for col_idx in range(y)]
 
     def _get_scale_statistics(self, dataset):
         """
@@ -540,8 +528,7 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
                 cols = None
             wide_cols = self._make_normals(num_samples, num_feats,
                                            scale=scales, mean=means,
-                                           cols=cols, format="wide",
-                                           seed=seed)
+                                           cols=cols, seed=seed)
             # Duplicate them to be the base for binary and inverse outputs
             wide_cols_named = [c.alias(i) for c, i
                                in zip(wide_cols, inverse_output_cols)] + \

--- a/sparkling_lime/metrics.py
+++ b/sparkling_lime/metrics.py
@@ -1,7 +1,8 @@
 """
 Stores methods for calculating metrics
 """
-from pyspark.sql.functions import col, sqrt, exp, pow
+from pyspark.sql.functions import col, sqrt, exp, pow, lit
+import pyspark.sql.functions as F
 from pyspark.sql.types import DoubleType
 from scipy.spatial import distance
 from pyspark.ml import Transformer, UnaryTransformer
@@ -9,7 +10,10 @@ from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
 from pyspark.ml.param.shared import HasInputCols, HasInputCol, HasOutputCol, HasSeed
 from pyspark.ml.linalg import VectorUDT
 from pyspark.ml.param import Param, Params, TypeConverters
+from pyspark.ml.feature import VectorAssembler, StandardScaler
 from pyspark import keyword_only
+import numpy as np
+from numpy.random import RandomState
 
 
 class HasDistanceMetric(Params):
@@ -191,3 +195,223 @@ class KernelWeight(HasKernelWidth, HasInputCol, HasOutputCol, Transformer,
             sqrt(exp(-(pow(col(inputCol), 2)) / kernelWidth ** 2)))
 
 
+class NeighborhoodGenerator(HasInputCols, HasOutputCol, HasSeed, Transformer,
+                            DefaultParamsWritable, DefaultParamsReadable):
+    neighborhoodSize = Param(Params._dummy(), "neighborhoodSize",
+                             ("The size of the neighborhood to generate; the  "
+                              "number of perturbed samples to generate."),
+                             typeConverter=TypeConverters.toInt)
+    discretizer = Param(Params._dummy(), "discretizer",
+                        ("A fitted QuartileDiscretizer or DecileDiscretizer "
+                         "(optional)"))
+    format = Param(Params._dummy(), "format",
+                   ("The format to use ('wide'/'narrow'. If 'narrow', the "
+                    "neighborhood will be output as a single 2darray column "
+                    "`outputCol` of size [neighborhoodSize][i], where `i` is "
+                    "the number of columns in the `inputCols` list. If "
+                    "'wide', the neighborhood will be output as `i` 1darray "
+                    "columns of length `neighborhoodSize`, named sequentially "
+                    "(i.e. <outputCol>_0, <outputCol>_1, ..., <outputCol>_n)"))
+    sampleAroundInstance = Param(Params._dummy(), "sampleAroundInstance",
+                                 ("If True, will sample continuous features in"
+                                  " in perturbed samples from a normal centered"
+                                  " at the instance being explained. Otherwise,"
+                                  " the normal is centered on the mean of the"
+                                  " feature data."),
+                                 typeConverter=TypeConverters.toBoolean)
+
+    @keyword_only
+    def __init__(self, inputCols=None, outputCol=None, neighborhoodSize=5000,
+                 discretizer=None, seed=None, sampleAroundInstance=False):
+        super(NeighborhoodGenerator, self).__init__()
+        self._setDefault(neighborhoodSize=5000, discretizer=None,
+                         sampleAroundInstance=False)
+        kwargs = self._input_kwargs
+        self.setParams(**kwargs)
+
+    @keyword_only
+    def setParams(self, inputCols=None, outputCol=None, neighborhoodSize=5000,
+                  discretizer=None, sampleAroundInstance=False, seed=None):
+        """
+        Sets params for this PairwiseEuclideanDistance transformer.
+        """
+        kwargs = self._input_kwargs
+        return self._set(**kwargs)
+
+    def setNeighborhoodSize(self, value):
+        """
+        Sets the value of :py:attr:neighborhoodSize
+        """
+        return self._set(neighborhoodSize=value)
+
+    def getNeighborhoodSize(self):
+        """
+        Returns the value of neighborhoodSize or the default value.
+        """
+        return self._getOrDefault(self.neighborhoodSize)
+
+    def setDiscretizer(self, value):
+        """
+        Sets the value of :py:attr:discretizer
+        """
+        return self._set(discretizer=value)
+
+    def getDiscretizer(self):
+        """
+        Returns the value of discretizer or the default value.
+        """
+        return self._getOrDefault(self.discretizer)
+
+    def setFormat(self, value):
+        """
+        Sets the value of :py:attr:format
+        """
+        return self._set(format=value)
+
+    def getFormat(self):
+        """
+        Returns the value of format or the default value.
+        """
+        return self._getOrDefault(self.format)
+
+    def setSampleAroundInstance(self, value):
+        """
+        Sets the value of :py:attr:sampleAroundInstance
+        """
+        return self._set(sampleAroundInstance=value)
+
+    def getSampleAroundInstance(self):
+        """
+        Returns the value of sampleAroundInstance or the default value.
+        """
+        return self._getOrDefault(self.sampleAroundInstance)
+
+    @staticmethod
+    def _make_zeroes(x, y, format):
+        """
+        Make a column of 2darray of zeros[x][y]
+        :param x: number of rows
+        :param y: number of columns
+        :return: `pyspark.sql.Column` of 2darray of zeros, in 1 column if
+            "narrow" format, and in `y` columns in "wide" format (named
+            numerically from [0,`y`-1])
+        """
+        if format == "narrow":
+            return F.array(*[F.array(*[lit(0)]*y)]*x)
+        elif format == "wide":
+            return [F.array([lit(0)] * x)] * y
+
+    @staticmethod
+    def _make_normals(x, y, format, scale, mean=(), cols=None, seed=None):
+        """
+        Make a column of 2darray of zeros[x][y]
+        :param x: number of rows
+        :param y: number of columns
+        :param scale: Iterable of len(`y`), of values by which to scale the
+            normal distribution (square root of the feature variance)
+        :param mean: Iterable of len(`y`) , of values values to add to the
+        scaled normal distribution, to center around (means of each feature)
+        :param cols: Values of columns to center the normal distribution around
+            instead of the mean. Only relevant if a value for `mean` is not
+            provided.
+        :return: `pyspark.sql.Column` of centered and scaled normal
+            distribution, in 1 column if "narrow" format, and in `y` columns
+            in "wide" format (named numerically from [0,`y`-1])
+        """
+        if mean:
+            center = mean
+        else:
+            center = cols
+
+        # Generate [x]*[y] samples of normal distribution, scale each value by
+        #   scaling factor and then add the center value
+        # For example, let `n` be a random sample from normal distribution,
+        #   `s` be the scaling factor for a feature, and `m` the mean for the
+        #    feature:
+        #       return (n*s) + m, for all s in scale and m in mean.
+        # So if x=2 and y=2:
+        #    return [[n1*s1 + m1, n2*s2 + m2], [n1`*s1 + m1, n2`*s2 + m2]]
+        if format == "narrow":
+            return F.array(
+                *[F.array(
+                    [randn * scaler + val
+                     for randn, scaler, val
+                     in zip(
+                         [F.randn(seed=seed) for i in range(y)], scale, center)
+                     ])
+                  for i in range(x)])
+        # Similar to above, but instead of nested 2darray, what would be the
+        # nesting structure is distributed over columns
+        # If use above example, x=2 & y=2,
+        #    return two columns: [n1*s1 + m1, n2*s2+m2]
+        #                      & [n1`*s1 + m1, n2`*s2 + m1]
+        elif format == "wide":
+            return [F.array(
+                        [randn * scaler + val
+                            for randn, scaler, val
+                            in zip(
+                                [F.randn(seed=seed) for i in range(x)], scale, center)
+                         ]
+                    )
+                    for i in range(y)]
+
+    def _get_statistics(self, dataset):
+        """
+        Gets the relative scaling factor and means of each feature.
+        """
+        ic = self.getOrDefault(self.inputCols)
+        assembler = VectorAssembler(inputCols=ic, outputCol="features")
+        assembled_data = assembler.transform(dataset)
+        scaler = StandardScaler(inputCol="features", outputCol="scaled")
+        scaler_model = scaler.fit(assembled_data)
+        scales = [s if s != 0 else 1 for s in scaler_model.std]
+        means = [m for m in scaler_model.mean]
+        return scales, means
+
+    # TODO: Decide on a format and get rid of the other one
+    def _transform(self, dataset):
+        ic = self.getOrDefault(self.inputCols)
+        oc = self.getOrDefault(self.outputCol)
+        discretizer = self.getOrDefault(self.discretizer)
+        num_samples = self.getOrDefault(self.neighborhoodSize)
+        num_feats = len(ic)
+        format = self.getOrDfeault(self.format)
+        seed = self.getOrDefault(self.seed)
+        sample_around_instance = self.getOrDefault(self.sampleAroundInstance)
+        scales, means = self._get_statistics(dataset)
+
+        # Generate a 2d array of zeros or samples from normal distribution,
+        #   size=[numSamples][numFeatures]
+        if discretizer:
+            if format == "narrow":
+                dataset = dataset.withColumn(
+                    oc,
+                    self._make_zeroes(num_samples, num_feats, format="narrow"))
+            elif format == "wide":
+                wide_cols = self._make_zeroes(num_samples, num_feats,
+                                              format="wide")
+                wide_cols_named = [c.alias("{}_{}".format(oc, n))
+                                   for c, n in zip(wide_cols, range(num_feats))]
+                dataset = dataset.select("*", *wide_cols_named)
+        else:
+            if sample_around_instance:     # Center around feature mean or value
+                cols = [col(c) for c in ic]
+                means = None
+            else:
+                cols = None
+
+            if format == "narrow":
+                dataset = dataset.withColumn(
+                    oc,
+                    self._make_normals(num_samples, num_feats, scale=scales,
+                                       mean=means, cols=cols, format="narrow",
+                                       seed=seed))
+            elif format == "wide":
+                wide_cols = self._make_normals(num_samples, num_feats,
+                                               scale=scales, mean=means,
+                                               cols=cols, format="wide",
+                                               seed=seed)
+                wide_cols_named = [c.alias("{}_{}".format(oc, n))
+                                   for c, n in zip(wide_cols, range(num_feats))]
+                dataset = dataset.select("*", *wide_cols_named)
+        return dataset

--- a/sparkling_lime/metrics.py
+++ b/sparkling_lime/metrics.py
@@ -10,10 +10,9 @@ from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
 from pyspark.ml.param.shared import HasInputCols, HasInputCol, HasOutputCol, HasSeed
 from pyspark.ml.linalg import VectorUDT
 from pyspark.ml.param import Param, Params, TypeConverters
-from pyspark.ml.feature import VectorAssembler, StandardScaler
+from pyspark.ml.feature import VectorAssembler, StandardScaler, Bucketizer
 from pyspark import keyword_only
-import numpy as np
-from numpy.random import RandomState
+from pyspark.ml import Pipeline
 
 
 class HasDistanceMetric(Params):
@@ -340,54 +339,86 @@ class NeighborhoodGenerator(Transformer, HasInputCols,
         return self._set(**kwargs)
 
     @staticmethod
+    def _make_bins(freqs):
+        """
+        Create splits from feature frequencies to use in
+        `pyspark.ml.feature.Bucketizer` instances.
+        :param freqs: List of (value, frequency) tuples
+        :return: Tuple of list of bins for a bucketizer and bin: value dictionary
+        """
+        bins = [0]
+        bin_map = {}
+        sorted_freqs = sorted(freqs, key=lambda x: x[1])
+        for i, f in enumerate(sorted_freqs):
+            bins.append(bins[i] + f[1])
+            bin_map.update({i: f[0]})
+        return bins, bin_map
+
+    @staticmethod
     def _make_random_choices_and_binarize(dataset, input_col, num_samples,
                                           feature_rate_dict,
                                           output_col="neighborhood",
                                           seed=None):
         """
-        Make
-
+        Make an array of structs, size `num_samples`, that are the result of
+        random sampling from all possible categorical feature values at the
+        rates they are present in the feature data. The struct contains the
+        `inverse` element, which is the sampled value, and the `binary`
+        element, which is a code that reflects whether the value is the same
+        (1.0) or different (0.0) from the original categorical value.
+        :param dataset: `pyspark.sql.DataFrame` of features in wide format
+        :param input_col: Name of the input column to generate samples from
+        :param num_samples: Number of samples to generate
+        :param feature_rate_dict: Dictionary of feature values to rates the
+        value occured in the dataset
+        :param seed: Random seed
         :return: dataset with output_col with an array of num_samples structs
         of value choice + binary class (is same/diff)
         """
-        binary_output_col = "binary"
-        inverse_output_col = "inverse"
-
-        random_state = np.random.RandomState(seed=seed)
         ordered_rates = [(k, v) for k, v in feature_rate_dict.items()]    # For safe iteration
-        other_cols = [c for c in dataset.columns if c != input_col]
-        idcol = str(hash("_make_random_choices_and_binarize"))
-        dataset = dataset.withColumn(idcol, F.monotonically_increasing_id())
-        dataset.cache()
+        bins, bin_map = NeighborhoodGenerator._make_bins(ordered_rates)
+        orig_cols = dataset.columns
+        cols = [F.rand(seed=seed).alias("inverse_{}_{}".format(input_col, i))
+                for i in range(num_samples)]
+        colnames = ["inverse_{}_{}".format(input_col, i)
+                    for i in range(num_samples)]
+        bucketed_colnames = ["bucketed_"+c for c in colnames]
+        dataset = dataset.select("*", *cols)
+        bucketizers = [Bucketizer(inputCol=ic, outputCol="bucketed_"+ic,
+                                  splits=bins)
+                       for ic in colnames]
+        pipeline = Pipeline(stages=bucketizers)
+        dataset = pipeline.fit(dataset).transform(dataset)\
+            .replace(bin_map, subset=bucketed_colnames)\
+            .drop(*colnames)
+        for c in bucketed_colnames:
+            dataset = dataset.withColumn(
+                "binary_"+c,
+                F.when(col(c) == col(input_col), 1).otherwise(
+                    0))
+            dataset = dataset.withColumn(
+                "struct_"+c,
+                F.struct(col(c).alias("inverse"),
+                         col("binary_"+c).alias("binary")))
         dataset = dataset.withColumn(
-                inverse_output_col,
-                F.array(
-                    [lit(float(random_state.choice(
-                        [r[0] for r in ordered_rates],
-                        size=1,
-                        replace=True,
-                        p=[r[1] for r in ordered_rates])[0]))
-                     for i in range(num_samples)]
-                ))
-        # Hard to iterate over array to make binarized column, so explode instead
-        dataset = dataset.withColumn(inverse_output_col,
-                                     F.explode(inverse_output_col))
-        dataset = dataset.withColumn(
-            binary_output_col,
-            F.when(col(inverse_output_col) == col(input_col), 1).otherwise(0))
-        dataset = dataset.withColumn(
-             output_col,
-             F.struct(inverse_output_col, binary_output_col))
-        dataset = dataset.groupBy(idcol, *other_cols)\
-            .agg(F.collect_list(output_col).alias(output_col),
-                 F.first(input_col).alias(input_col))\
-            .drop(idcol)
+            output_col,
+            F.array([col("struct_"+c) for c in bucketed_colnames]))
+        dataset = dataset.select(*orig_cols, output_col)
         return dataset
 
     @staticmethod
     def _make_normals(x, y, scale, mean=(), cols=None, seed=None):
         """
-        Make a column of 2darray of zeros[x][y]
+        Make `y` columns of an array of `x` samples of a normal distribution,
+        scaled with `scale` and centered around a mean or the values in
+        `cols`.
+        For example, let `n` be a random sample from normal distribution,
+        `s` be the scaling factor for a feature, and `m` the mean for the
+        feature:
+              return (n*s) + m
+        If x=3 & y=2, return two columns:
+            [n1*s1 + m1, n2*s1+m1, n3*s1*m1]
+            & [n1`*s2 + m2, n2`*s2 + m2, n3`*s2+m2]
         :param x: number of rows
         :param y: number of columns
         :param scale: Iterable of len(`y`), of values by which to scale the
@@ -405,26 +436,12 @@ class NeighborhoodGenerator(Transformer, HasInputCols,
             center = mean
         else:
             center = cols
-
-        # For `y` columns, generate `x` samples of normal distribution, scale
-        #   each value by scaling factor and then add the center value.
-        # For example, let `n` be a random sample from normal distribution,
-        #   `s` be the scaling factor for a feature, and `m` the mean for the
-        #    feature:
-        #       return (n*s) + m
-        # If x=3 & y=2,
-        #    return two columns: [n1*s1 + m1, n2*s1+m1, n3*s1*m1]
-        #                      & [n1`*s2 + m2, n2`*s2 + m2, n3`*s2+m2]
         return [F.array(
-                    [randn * scaler + val
-                        for randn, scaler, val
-                        in zip(
-                            [F.randn(seed=seed) for i in range(x)],
-                            [scale[col_idx]]*x,
-                            [center[col_idx]]*x)
-                     ]
-                )
-                for col_idx in range(y)]
+                    [F.struct(
+                        *[(F.rand() * scale[j] + center[j]).alias(n)
+                          for n in ["inverse", "binary"]])
+                        for i in range(x)])
+                for j in range(y)]
 
     def _get_scale_statistics(self, dataset, subset=()):
         """
@@ -500,17 +517,31 @@ class NeighborhoodGenerator(Transformer, HasInputCols,
 
     def _transform(self, dataset):
         """
+        Generates a neighborhood around a prediction.
+        For numerical features, perturb them by sampling from a normal
+        distribution and doing the inverse operation of mean-centering and
+        scaling, according to the means and stds in the training data. For
+        categorical feature, perturb by sampling according to the training
+        distribution, and making a binary feature that is 1 when the value
+        is the same as the instance being explained.
+
+        The neighborhood is an array of structs with the following schema:
+
         Output schema:
             original dataset + for each feature column:
 
         root
-         |-- inverse_<featureName>: array (nullable = true)
-         |    |-- element: struct (containsNull = true)
+         |-- <outputCol>: array (nullable = true)
+         |    |-- element: struct (containsNull = false)
          |    |    |-- inverse: double (nullable = false)
          |    |    |-- binary: double (nullable = false)
 
-        :param dataset:
-        :return:
+        For continuous variables, the 'binary' element is the same as the
+        'inverse' element (since it is only relevant for categoical variables).
+
+        :param dataset: `pyspark.sql.DataFrame` of features in wide format
+        (one feature per column)
+        :return: Dataset with original + perturbed features in wide format
         """
         # Configure column names and save a map of inputs => outputs
         ic = self.getOrDefault(self.inputCols)
@@ -538,11 +569,13 @@ class NeighborhoodGenerator(Transformer, HasInputCols,
             dataset = self._make_random_choices_and_binarize(
                     dataset, c,  num_samples, feature_freqs[c],
                     inverse_col_map[c])
+            dataset.cache()
             # Undiscretize if the column is a discretized continuous feature
             if discretizer:
                 if c in discretizer.to_discretize:
                     dataset = self._undiscretize_helper(
                         dataset, inverse_col_map[c], c, discretizer)
+            dataset.cache()
         if continuous_cols:
             num_feats = len(continuous_cols)
             inverse_subset = [inverse_col_map[c] for c in continuous_cols]
@@ -556,8 +589,7 @@ class NeighborhoodGenerator(Transformer, HasInputCols,
             wide_cols = self._make_normals(num_samples, num_feats,
                                            scale=scales, mean=means,
                                            cols=cols, seed=seed)
-            wide_cols_named = [F.struct(c.alias("inverse"), c.alias("binary"))
-                               .alias(n)
+            wide_cols_named = [c.alias(n)
                                for c, n in zip(wide_cols, inverse_subset)]
             dataset = dataset.select("*", *wide_cols_named)
 

--- a/sparkling_lime/metrics.py
+++ b/sparkling_lime/metrics.py
@@ -460,8 +460,9 @@ class NeighborhoodGenerator(Transformer, HasInputCols,
         if not colnames:
             colnames = [str(j) for j in range(y)]
         return [F.array(
-                    *[F.rand() for i in range(x)]).alias(j)
-                for j in colnames]
+                    *[(F.randn(seed=seed) * scale[j] + center[j])
+                      for i in range(x)]).alias(colnames[j])
+                for j in range(y)]
 
     def _get_scale_statistics(self, dataset, subset=()):
         """
@@ -596,6 +597,8 @@ class NeighborhoodGenerator(Transformer, HasInputCols,
                         dataset, inverse_col_map[c], c, discretizer)
                 else:
                     binary_cols.append(c)
+            else:
+                binary_cols.append(c)
             dataset.cache()
         if continuous_cols:
             num_feats = len(continuous_cols)
@@ -611,7 +614,7 @@ class NeighborhoodGenerator(Transformer, HasInputCols,
                                            scale=scales, mean=means,
                                            cols=cols, seed=seed,
                                            colnames=inverse_subset)
-            dataset = dataset.select("*", wide_cols)
+            dataset = dataset.select("*", *wide_cols)
 
         generated_cols = list(inverse_col_map.values())
         dataset = dataset.withColumn(

--- a/sparkling_lime/metrics.py
+++ b/sparkling_lime/metrics.py
@@ -239,7 +239,6 @@ class NeighborhoodGeneratorParams(Params):
                                "the names of the inputCols with 'inverse_'."),
                               typeConverter=TypeConverters.toListString)
 
-    @keyword_only
     def __init__(self):
         super(NeighborhoodGeneratorParams, self).__init__()
 
@@ -314,16 +313,18 @@ class NeighborhoodGeneratorParams(Params):
         return self.getOrDefault(self.inverseOutputCols)
 
 
-class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
-                            HasOutputCol, HasSeed, Transformer,
-                            DefaultParamsWritable, DefaultParamsReadable):
+class NeighborhoodGenerator(Transformer, HasInputCols,
+                            HasOutputCol, HasSeed, NeighborhoodGeneratorParams):
+    """
+    Generate a neighborhood around features.
+    """
 
     @keyword_only
     def __init__(self, inputCols=None, outputCol=None, neighborhoodSize=5000,
                  discretizer=None, seed=None, sampleAroundInstance=False,
                  categoricalCols=None):
         super(NeighborhoodGenerator, self).__init__()
-        self._setDefault(neighborhoodSize=5000, discretizer=None,
+        self._setDefault(inputCols=None, neighborhoodSize=5000, discretizer=None,
                          sampleAroundInstance=False, categoricalCols=None)
         kwargs = self._input_kwargs
         self.setParams(**kwargs)
@@ -354,7 +355,7 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
 
         random_state = np.random.RandomState(seed=seed)
         ordered_rates = [(k, v) for k, v in feature_rate_dict.items()]    # For safe iteration
-
+        other_cols = [c for c in dataset.columns if c != input_col]
         idcol = str(hash("_make_random_choices_and_binarize"))
         dataset = dataset.withColumn(idcol, F.monotonically_increasing_id())
         dataset.cache()
@@ -377,7 +378,7 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
         dataset = dataset.withColumn(
              output_col,
              F.struct(inverse_output_col, binary_output_col))
-        dataset = dataset.groupBy(idcol)\
+        dataset = dataset.groupBy(idcol, *other_cols)\
             .agg(F.collect_list(output_col).alias(output_col),
                  F.first(input_col).alias(input_col))\
             .drop(idcol)
@@ -479,19 +480,22 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
         df = dataset.withColumn(id_col, F.monotonically_increasing_id())
         df.cache()    # Force compute of id
         df = df.withColumn(subset, F.explode(subset))\
-            .withColumn("inverse", col(subset)["inverse"])\
-            .withColumn("binary", col(subset)["binary"])
-        # Get statistics from the source column (original feature data)
-        means, stds, mins, maxs = (discretizer.means[orig_col],
-                                   discretizer.stds[orig_col],
-                                   discretizer.mins[orig_col],
-                                   discretizer.maxs[orig_col])
-        df = discretizer.static_undiscretize(dataset, ["inverse"], means, stds,
-                                             mins, maxs, self.getSeed())
+            .withColumn("inverse", col(subset)["inverse"])
+        means, stds, mins, maxs = ({"inverse": discretizer.means[orig_col]},
+                                   {"inverse": discretizer.stds[orig_col]},
+                                   {"inverse": discretizer.mins[orig_col]},
+                                   {"inverse": discretizer.maxs[orig_col]})
+        df = discretizer.static_undiscretize(df, ["inverse"],
+                                             means,
+                                             stds,
+                                             mins,
+                                             maxs,
+                                             discretizer.random_state)
         df = df.groupBy(id_col, *other_cols)\
             .agg(F.collect_list(F.struct(col("inverse"),
                                          col("inverse").alias("binary")))    # Only kept to avoid KeyError
-                 .alias(subset))
+                 .alias(subset))\
+            .drop(id_col)
         return df
 
     def _transform(self, dataset):
@@ -540,7 +544,7 @@ class NeighborhoodGenerator(NeighborhoodGeneratorParams, HasInputCols,
             if discretizer:
                 if c in discretizer.to_discretize:
                     dataset = self._undiscretize_helper(
-                        dataset, c, inverse_to_orig_col_map[c], discretizer)
+                        dataset, inverse_col_map[c], c, discretizer)
         if continuous_cols:
             scales, means = self._get_scale_statistics(dataset,
                                                        subset=continuous_cols)

--- a/sparkling_lime/tests/test_lime_tabular.py
+++ b/sparkling_lime/tests/test_lime_tabular.py
@@ -1,0 +1,97 @@
+from pyspark.ml.tests import SparkSessionTestCase
+from pyspark.ml.base import Estimator
+from sparkling_lime.lime_tabular import ReusedEstimator, LocalLinearLearner
+from pyspark.ml.regression import LinearRegression
+from pyspark.ml.linalg import Vectors
+from pyspark.sql.functions import col
+
+
+class TestReusedEstimator(SparkSessionTestCase):
+    def test_fit_multiple_datasets(self):
+        mre = MockReusedLinReg()
+        data = [(0, Vectors.dense([-1.0, -1.0]),),
+                (0, Vectors.dense([-1.0, 1.0]),),
+                (1, Vectors.dense([1.0, -1.0]),),
+                (1, Vectors.dense([1.0, 1.0]),)]
+        data2 = [(1, Vectors.dense([-1.0, -1.0]),),
+                 (1, Vectors.dense([-1.0, 1.0]),),
+                 (0, Vectors.dense([1.0, -1.0]),),
+                 (0, Vectors.dense([1.0, 1.0]),)]
+        dataset = self.spark.createDataFrame(data, ["label", "features"])
+        dataset2 = self.spark.createDataFrame(data2, ["label", "features"])
+        datasets = [dataset]*5 + [dataset2]*5
+        epm = MockReusedLinReg().extractParamMap()
+        models = [0]*10
+        for index, model in mre.fitMultipleDatasets(mre, datasets, epm):
+            models[index] = model
+        for index, model in enumerate(models):
+            with self.subTest("Model transforms the data"):
+                self.assertCountEqual(["label", "features", "prediction"],
+                                      model.transform(dataset).columns)
+                self.assertEqual("<class 'pyspark.sql.dataframe.DataFrame'>",
+                                 str(type(model.transform(dataset))))
+        with self.subTest("Model is actually fitted on data "
+                          "(not copied instance"):
+            correct_transforms = models[0].transform(datasets[0])
+            incorrect_transforms = models[0].transform(datasets[-1])
+            correct_preds = correct_transforms.filter(
+                col("label") == col("prediction")).count()
+            incorrect_preds = incorrect_transforms.filter(
+                col("label") != col("prediction")).count()
+            self.assertEqual(4, correct_preds,
+                             ("Expected all predictions to be correct, but "
+                              "only {} were.".format(correct_preds)))
+            self.assertEqual(4, incorrect_preds,
+                             ("Expected all predictions to be incorrect, but "
+                              "only {} were.".format(incorrect_preds)))
+
+
+class TestLocalLinearLearner(SparkSessionTestCase):
+    def test_parallel_fitting(self):
+        lll = LocalLinearLearner()
+        data = [(0, Vectors.dense([-1.0, -1.0]),),
+                (0, Vectors.dense([-1.0, 1.0]),),
+                (1, Vectors.dense([1.0, -1.0]),),
+                (1, Vectors.dense([1.0, 1.0]),)]
+
+        dataset = self.spark.createDataFrame(data, ["label", "features"])
+        datasets = [dataset] * 10
+
+        lll.setParallelism(1)
+        serial_models = lll.fit(datasets).getFittedModels()
+        lll.setParallelism(2)
+        parallel_models = lll.fit(datasets).getFittedModels()
+        self.assertEqual(len(serial_models), len(parallel_models),
+                         "Number of models processed serially was not the same"
+                         " as the number of models processed in parallel.")
+
+
+class TestParallelTransformer(SparkSessionTestCase):
+    def test_parallel_transform(self):
+        lll = LocalLinearLearner()
+        data = [(0, Vectors.dense([-1.0, -1.0]),),
+                (0, Vectors.dense([-1.0, 1.0]),),
+                (1, Vectors.dense([1.0, -1.0]),),
+                (1, Vectors.dense([1.0, 1.0]),)]
+
+        dataset = self.spark.createDataFrame(data, ["label", "features"])
+        datasets = [dataset] * 10
+        model = lll.fit(datasets)
+        model.setParallelism(1)
+        serial_transformed = model.transform(datasets)
+        model.setParallelism(2)
+        parallel_transformed = model.transform(datasets)
+        self.assertEqual(len(serial_transformed), len(parallel_transformed),
+                         "Number of transformed datasets processed serially"
+                         " was not the same as the datasets processed in"
+                         " parallel.")
+        for s, p in zip(serial_transformed, parallel_transformed):
+            self.assertEqual(s.columns, p.columns,
+                             "Columns of transformed data processed serially"
+                             " was not the same as the datasets processed"
+                             " in parallel.")
+
+class MockReusedLinReg(LinearRegression, ReusedEstimator):
+    def __init__(self):
+        super().__init__()
+

--- a/sparkling_lime/tests/test_metrics.py
+++ b/sparkling_lime/tests/test_metrics.py
@@ -123,60 +123,45 @@ class KernelWidthTests(SparkSessionTestCase):
 
 class NeighborhoodGeneratorTests(SparkSessionTestCase):
 
-    def test_random_choice_binarize(self):
+    def test_random_choice(self):
         data = [[0], [0], [1], [1], [1], [1], [1], [1], [1], [1]]
         rates = {0: 0.2, 1: 0.8}
         df = self.spark.createDataFrame(data, ["c1"])
         actual = metrics.NeighborhoodGenerator.\
-            _make_random_choices_and_binarize(df, "c1", 100, rates)
+            _make_random_choices(df, "c1", 100, rates)
         sample_row = actual.head()
-        # orig_val = sample_row["c1"]
         self.assertEqual(10, actual.count(), "Wrong count. Expected 10, got {}"
                          .format(actual.count()))
         self.assertEqual(100, len(sample_row["neighborhood"]),
                          "Wrong neighborhood size. Expected 100, got {}"
                          .format(len(sample_row["neighborhood"])))
-        sample_vals = [row["inverse"] for row in sample_row["neighborhood"]]
-        self.assertAlmostEqual(0.8, float(np.mean(sample_vals)),
+        self.assertAlmostEqual(0.8, float(np.mean(sample_row["neighborhood"])),
                                delta=0.1,
                                msg=("Expected 1's to be sampled at rate of 0.8"
-                                    " , got {}").format(np.mean(sample_vals)))
-        orig_val = sample_row["c1"]
-        with self.subTest("Binary classification is correct."):
-            for row in sample_row["neighborhood"]:
-                if row["inverse"] == orig_val:
-                    self.assertEqual(1.0, row["binary"],
-                                     ("Expected 1.0 for class ('same'), but got"
-                                     " {}").format(row["binary"]))
-                else:
-                    self.assertEqual(0.0, row["binary"],
-                                     ("Expected 1.0 for class ('diff'), but got"
-                                     " {}").format(row["binary"]))
+                                    " , got {}")
+                               .format(np.mean(sample_row["neighborhood"])))
 
     def test_make_normals(self):
         df = self.spark.createDataFrame([[i] for i in range(10)], ["c1"])
         with self.subTest("Sample around a mean works as expected"):
-            means = (-1000, 100, 1000, 10, 0)
-            scales = (0, 0.1, 1, 10, 1)
+            means = (-1000, 10, 0)
+            scales = (0, 1, 10)
             actual_cols = metrics.NeighborhoodGenerator._make_normals(
-                150, 5, scales, mean=means)
-            actual_mean_df = df.select([c.alias(str(i))
-                                        for c, i
-                                        in zip(actual_cols,
-                                               range(len(actual_cols)))])
-            self.assertEqual(5, len(actual_mean_df.columns),
+                300, 3, scales, mean=means)
+            actual_mean_df = df.select(actual_cols)
+            self.assertEqual(3, len(actual_mean_df.columns),
                              "Expected 5 columns but got {}"
                              .format(len(df.columns)))
             self.assertEqual(10, actual_mean_df.count(),
                              "Expected 10 rows but got {}"
                              .format(actual_mean_df.count()))
             sample_row = actual_mean_df.head()
-            for i in range(5):
+            for i in range(3):
                 if means[i] == 0:
-                    delta = 0.2
+                    delta = 1
                 else:
-                    delta = means[i]*0.2
-                self.assertEqual(150, len(sample_row[i]),
+                    delta = means[i]*0.1
+                self.assertEqual(300, len(sample_row[i]),
                                  "Expected 150 samples but got {}"
                                  .format(len(sample_row[i])))
                 self.assertAlmostEqual(
@@ -193,7 +178,7 @@ class NeighborhoodGeneratorTests(SparkSessionTestCase):
             cols = [col("c1")]
             scales = [1]
             actual_cols = metrics.NeighborhoodGenerator._make_normals(
-                150, 1, scales, cols=cols)
+                300, 1, scales, cols=cols)
             actual_sample_df = df.select([c.alias(str(i)) for c, i
                                           in zip(actual_cols,
                                                  range(len(actual_cols)))])
@@ -206,10 +191,10 @@ class NeighborhoodGeneratorTests(SparkSessionTestCase):
             collection = actual_sample_df.collect()
             for i in range(10):
                 if i == 0:
-                    delta = 0.2
+                    delta = 1
                 else:
-                    delta = i*0.2
-                self.assertEqual(150, len(collection[i][0]),
+                    delta = i*0.1
+                self.assertEqual(300, len(collection[i][0]),
                                  "Expected 150 samples but got {}"
                                  .format(len(collection[i][0])))
                 self.assertAlmostEqual(i, float(np.mean(collection[i][0])),
@@ -226,9 +211,9 @@ class NeighborhoodGeneratorTests(SparkSessionTestCase):
             [[i, j] for i, j in zip(range(10), [1]*10)], ["c1", "c2"])
         ng = metrics.NeighborhoodGenerator(inputCols=["c1", "c2"])
         actual_scales, actual_means = ng._get_scale_statistics(df)
-        self.assertEqual(4.5, actual_means[0],
-                         "Wrong mean. Expected 4.5, got {}"
-                         .format(actual_means[0]))
+        self.assertAlmostEqual(4.5, actual_means[0],
+                               "Wrong mean. Expected 4.5, got {}"
+                               .format(actual_means[0]))
         self.assertEqual(1, actual_means[1], "Wrong mean. Expected 1, got {}"
                          .format(actual_means[1]))
         self.assertEqual(1, actual_scales[1],
@@ -271,22 +256,24 @@ class NeighborhoodGeneratorTests(SparkSessionTestCase):
                                  "Bins didn't map to correct values.")
 
     def test_neighborhood_generator_transform(self):
-        pdf = pd.DataFrame({"f0": np.random.normal(0, 1, 100),
+        pdf = pd.DataFrame({"id": list(range(100)),
+                            "f0": np.random.normal(0, 1, 100),
                             "f1": np.random.normal(100, 10, 100),
                             "f2": [0]*80 + [1]*20})
         df = self.spark.createDataFrame(pdf)
-        discretizer = QuartileDiscretizer(df, ["f2"], df.columns)
+        cols = ["f0", "f1", "f2"]
+        discretizer = QuartileDiscretizer(df, ["f2"], cols)
         disc_df = discretizer.discretize(df)
 
         disc_nGenerator = metrics.NeighborhoodGenerator(
-            inputCols=df.columns, neighborhoodSize=100,
-            discretizer=discretizer, seed=42)
+            inputCols=cols, neighborhoodSize=10,
+            discretizer=discretizer, seed=None)
         undisc_nGeneratorInstance = metrics.NeighborhoodGenerator(
-            inputCols=df.columns, neighborhoodSize=100,
-            seed=42, sampleAroundInstance=True, categoricalCols=["f2"])
+            inputCols=cols, neighborhoodSize=10,
+            seed=None, sampleAroundInstance=True, categoricalCols=["f2"])
         undisc_nGeneratorMean = metrics.NeighborhoodGenerator(
-            inputCols=df.columns, neighborhoodSize=100,
-            seed=42, sampleAroundInstance=False, categoricalCols=["f2"])
+            inputCols=cols, neighborhoodSize=10,
+            seed=None, sampleAroundInstance=False, categoricalCols=["f2"])
 
         actual_disc = disc_nGenerator.transform(disc_df)
         actual_mean = undisc_nGeneratorMean.transform(df)
@@ -298,38 +285,44 @@ class NeighborhoodGeneratorTests(SparkSessionTestCase):
         for name, result in types:
             with self.subTest("Output has expected format for data type: '{}'"
                               .format(name)):
-                sample_row = result.head()
-                self.assertEqual(100, result.count(),
-                                 "Expected 100 rows but got {}"
+                self.assertEqual(1000, result.count(),
+                                 "Expected 1000 rows but got {}"
                                  .format(result.count()))
-                self.assertCountEqual(["f0", "f1", "f2", "inverse_f1",
-                                       "inverse_f2", "inverse_f0"],
+                self.assertCountEqual(["id", "f0", "f1", "f2", "inverse_f1",
+                                       "inverse_f2", "inverse_f0", "binary_f2"],
                                       result.columns,
                                       "Unexpected columns in result for {}"
                                       .format(name))
-                cat_vals = [r["inverse"] for r in sample_row["inverse_f2"]]
-                cat_binary = [r["binary"] for r in sample_row["inverse_f2"]]
-
-                self.assertCountEqual([0.0, 1.0], list(set(cat_vals)),
-                                      "Found a value != 0 or 1 in values.")
-                self.assertCountEqual([0.0, 1.0], list(set(cat_binary)),
-                                      "Found a value != 0 or 1 in binary "
-                                      "values.")
-                for col in ["inverse_f0", "inverse_f1", "inverse_f2"]:
-                    self.assertEqual(100, len(sample_row[col]),
-                                     ("Expected neighborhood of 100 but got"
-                                      " {} for column {}, inverse").format(
-                                         len(sample_row[col]), col))
-                    self.assertEqual(
-                        2, len(sample_row[col][random.randint(0, 100)]),
-                        "Didn't get the expected 2 values for each sample.")
-            for col in ["inverse_f0", "inverse_f1", "inverse_f2"]:
+                one_ex = result.filter(col("id") == random.randint(0, 99))
+                self.assertEqual(10, one_ex.count(),
+                                 ("Expected neighborhood of 10 but got"
+                                  " {}".format(one_ex.count())))
+            with self.subTest("Binary output is correct"):
+                same = result.filter(col("inverse_f2") == col("f2"))\
+                    .select("binary_f2").distinct().collect()
+                diff = result.filter(col("inverse_f2") != col("f2"))\
+                    .select("binary_f2").distinct().collect()
+                self.assertEqual(1, len(same), "Expected only 1 value.")
+                self.assertEqual(1, len(diff), "Expected only 1 value.")
+                self.assertEqual(1.0, same[0]["binary_f2"],
+                                 ("Expected binary value of 1.0 when "
+                                  "sampled value is the same, got {}"
+                                  .format(same[0]["binary_f2"])))
+                self.assertEqual(0.0, diff[0]["binary_f2"],
+                                 ("Expected binary value of 0.0 when "
+                                  "sampled value is the same, got {}"
+                                  .format(diff[0]["binary_f2"])))
+            for c in ["inverse_f0", "inverse_f1", "inverse_f2"]:
                 with self.subTest("Output has unique values for each "
-                                  " neighborhood: column {}".format(col)):
-                    collection = result.collect()
+                                  " neighborhood: {}".format(c)):
                     random_samples = [random.randint(0, 100) for i in range(2)]
-                    self.assertNotEqual(collection[random_samples[0]][col],
-                                        collection[random_samples[1]][col],
+                    hood0 = [r[c] for r in
+                             result.filter(col("id") == random_samples[0])\
+                             .select(c).collect()]
+                    hood1 = [r[c] for r in
+                             result.filter(col("id") == random_samples[1])\
+                             .select(c).collect()]
+                    self.assertNotEqual(hood0, hood1,
                                         "Expected unique values but got "
                                         "duplicate samples for column {}"
-                                        .format(col))
+                                        .format(c))

--- a/sparkling_lime/tests/test_metrics.py
+++ b/sparkling_lime/tests/test_metrics.py
@@ -1,22 +1,15 @@
 from sparkling_lime import metrics
+from sparkling_lime.discretize import QuartileDiscretizer
 from pyspark.ml.linalg import Vectors
 from unittest import TestCase
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, struct
+import numpy as np
+import pandas as pd
+from pyspark.ml.tests import SparkSessionTestCase
 
 
-class TestMetrics(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.spark = SparkSession.builder.master("local[4]").getOrCreate()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.spark.sparkContext.stop()
-
-    def test_kernel(self):
-        pass
+class PairwiseDistanceTests(SparkSessionTestCase):
 
     def test_pairwise_distance_vector(self):
         data = [(0, Vectors.dense([-1.0, -1.0]),),
@@ -84,6 +77,8 @@ class TestMetrics(TestCase):
                     "Distances are calculated correctly: i={}".format(r["id"])):
                 self.assertAlmostEqual(r["output"], expected[r["id"]])
 
+class KernelWidthTests(SparkSessionTestCase):
+
     def test_kernel_weight(self):
         data = [[0, 0.0], [1, 2.0], [2, 2.0], [3, 2.8284271247461903]]
         df = self.spark.createDataFrame(data, ["id", "distances"])
@@ -123,3 +118,158 @@ class TestMetrics(TestCase):
             with self.subTest(
                     "Distances are calculated correctly: i={}".format(r["id"])):
                 self.assertAlmostEqual(r["output"], expected[r["id"]])
+
+
+class NeighborhoodGeneratorTests(SparkSessionTestCase):
+
+    def test_random_choice_binarize(self):
+        data = [[0], [0], [1], [1], [1], [1], [1], [1], [1], [1]]
+        rates = {0: 0.2, 1: 0.8}
+        df = self.spark.createDataFrame(data, ["c1"])
+        actual = metrics.NeighborhoodGenerator._make_random_choices_and_binarize(
+            df, "c1", 100, rates)
+        sample_row = actual.head()
+        # orig_val = sample_row["c1"]
+        self.assertEqual(10, actual.count(), "Wrong count. Expected 10, got {}"
+                         .format(actual.count()))
+        self.assertEqual(100, len(sample_row["neighborhood"]),
+                         "Wrong neighborhood size. Expected 100, got {}"
+                         .format(len(sample_row["neighborhood"])))
+        sample_vals = [row["inverse"] for row in sample_row["neighborhood"]]
+        self.assertAlmostEqual(0.8, float(np.mean(sample_vals)),
+                               delta=0.1,
+                               msg=("Expected 1's to be sampled at rate of 0.8"
+                                    " , got {}").format(np.mean(sample_vals)))
+        orig_val = sample_row["c1"]
+        with self.subTest("Binary classification is correct."):
+            for row in sample_row["neighborhood"]:
+                if row["inverse"] == orig_val:
+                    self.assertEqual(1.0, row["binary"],
+                                     ("Expected 1.0 for class ('same'), but got"
+                                     " {}").format(row["binary"]))
+                else:
+                    self.assertEqual(0.0, row["binary"],
+                                     ("Expected 1.0 for class ('diff'), but got"
+                                     " {}").format(row["binary"]))
+
+    def test_make_normals(self):
+        df = self.spark.createDataFrame([[i] for i in range(10)], ["c1"])
+        with self.subTest("Sample around a mean works as expected"):
+            means = (-1000, 100, 1000, 10, 0)
+            scales = (0, 0.1, 1, 10, 1)
+            actual_cols = metrics.NeighborhoodGenerator._make_normals(
+                150, 5, scales, mean=means)
+            actual_mean_df = df.select([c.alias(str(i))
+                                        for c, i in zip(actual_cols,
+                                                        range(len(actual_cols)))])
+            self.assertEqual(5, len(actual_mean_df.columns),
+                             "Expected 5 columns but got {}"
+                             .format(len(df.columns)))
+            self.assertEqual(10, actual_mean_df.count(),
+                             "Expected 10 rows but got {}"
+                             .format(actual_mean_df.count()))
+            sample_row = actual_mean_df.head()
+            for i in range(5):
+                if means[i] == 0:
+                    delta = 0.2
+                else:
+                    delta = means[i]*0.2
+                self.assertEqual(150, len(sample_row[i]),
+                                 "Expected 150 samples but got {}"
+                                 .format(len(sample_row[i])))
+                self.assertAlmostEqual(
+                    means[i], float(np.mean(sample_row[i])), delta=delta,
+                    msg=("Expected mean of {} but got {}"
+                         .format(means[i], np.mean(sample_row[i]))))
+                self.assertAlmostEqual(
+                    scales[i], float(np.std(sample_row[i])),
+                    delta=scales[i]*0.2,
+                    msg=("Expected scale of {} but got {}"
+                         .format(scales[i], np.std(sample_row[i]))))
+
+        with self.subTest("Sample around values works as expected"):
+            cols = [col("c1")]
+            scales = [1]
+            actual_cols = metrics.NeighborhoodGenerator._make_normals(
+                150, 1, scales, cols=cols)
+            actual_sample_df = df.select([c.alias(str(i)) for c, i
+                                          in zip(actual_cols,
+                                                 range(len(actual_cols)))])
+            self.assertEqual(1, len(actual_sample_df.columns),
+                             "Expected 1 column but got {}"
+                             .format(len(actual_sample_df.columns)))
+            self.assertEqual(10, actual_sample_df.count(),
+                             "Expected 10 rows but got {}"
+                             .format(len(actual_sample_df.columns)))
+            collection = actual_sample_df.collect()
+            for i in range(10):
+                if i == 0:
+                    delta = 0.2
+                else:
+                    delta = i*0.2
+                self.assertEqual(150, len(collection[i][0]),
+                                 "Expected 150 samples but got {}"
+                                 .format(len(collection[i][0])))
+                self.assertAlmostEqual(i, float(np.mean(collection[i][0])),
+                                       delta=delta,
+                                       msg=("Expected mean {} but got {}"
+                                       .format(i, np.mean(collection[i][0]))))
+                self.assertAlmostEqual(1, float(np.std(collection[i][0])),
+                                       delta=0.2,
+                                       msg=("Expected scale 1 but got {}"
+                                            .format(np.std(collection[i][0]))))
+
+    def test_get_scale_statistics(self):
+        df = self.spark.createDataFrame(
+            [[i, j] for i, j in zip(range(10), [1]*10)], ["c1", "c2"])
+        ng = metrics.NeighborhoodGenerator(inputCols=["c1", "c2"])
+        actual_scales, actual_means = ng._get_scale_statistics(df)
+        self.assertEqual(4.5, actual_means[0], "Wrong mean. Expected 4.5, got {}"
+                         .format(actual_means[0]))
+        self.assertEqual(1, actual_means[1], "Wrong mean. Expected 1, got {}"
+                         .format(actual_means[1]))
+        self.assertEqual(1, actual_scales[1],
+                         "Wrong scaler factor (stdev). Expected 1, got {}"
+                         .format(actual_scales[1]))
+        self.assertEqual(3.0277, round(actual_scales[0], 4),
+                         "Wrong scaler factor (stdev). Expected 3.0277, got {}"
+                         .format(actual_scales[0]))
+
+    def test_get_feature_freqs(self):
+        df = self.spark.createDataFrame(
+            [[i, j] for i, j in zip([1]*5 + [0]*5, [1]*10)], ["c1", "c2"])
+        ng = metrics.NeighborhoodGenerator(inputCols=["c1", "c2"])
+        actual_freqs = ng._get_feature_freqs(df)
+        self.assertEqual(2, len(actual_freqs.keys()))
+        self.assertDictEqual({1: 0.5, 0: 0.5}, actual_freqs["c1"],
+                             "Expected 0.5 frequencies for both values. Got"
+                             "{}".format(actual_freqs["c1"]))
+        self.assertDictEqual({1: 1}, actual_freqs["c2"],
+                             "Expected frequency of 1. Got {}"
+                             .format(actual_freqs["c2"]))
+
+    def test_neighborhood_generator(self):
+        pdf = pd.DataFrame({"f0": np.random.normal(0, 1, 100),
+                            "f1": np.random.normal(100, 10, 100),
+                            "f2": [0]*80 + [1]*20})
+        df = self.spark.createDataFrame(pdf)
+        discretizer = QuartileDiscretizer(df, ["f2"], df.columns)
+        disc_df = discretizer.discretize(df)
+
+        disc_nGenerator = metrics.NeighborhoodGenerator(
+            inputCols=df.columns, neighborhoodSize=100,
+            discretizer=discretizer, seed=42)
+        undisc_nGeneratorInstance = metrics.NeighborhoodGenerator(
+            inputCols=df.columns, neighborhoodSize=100,
+            seed=42, sampleAroundInstance=True, categoricalCols=["f2"])
+        undisc_nGeneratorMean = metrics.NeighborhoodGenerator(
+            inputCols=df.columns, neighborhoodSize=100,
+            seed=42, sampleAroundInstance=False, categoricalCols=["f2"])
+
+        with self.subTest("Expected values returned for discretized data."):
+
+            actual = disc_nGenerator.transform(disc_df)
+            actual.show(truncate=False)
+
+        with self.subTest("Expected values returned for undiscretized data."):
+            pass

--- a/sparkling_lime/tests/test_metrics.py
+++ b/sparkling_lime/tests/test_metrics.py
@@ -70,13 +70,14 @@ class PairwiseDistanceTests(SparkSessionTestCase):
         df = self.spark.createDataFrame(data, ["id", "other", "orig"])
         df = df.withColumn("features", struct("orig", "other"))
         d1 = metrics.PairwiseDistance(inputCol="features", outputCol="output",
-                                      metric="euclidean")
+                                      distanceMetric="euclidean")
         actual = d1.transform(df).select("id", "output").collect()
         expected = {0: 0.0, 1: 2.0, 2: 2.0, 3: 2.8284271247461903}
         for r in actual:
             with self.subTest(
                     "Distances are calculated correctly: i={}".format(r["id"])):
                 self.assertAlmostEqual(r["output"], expected[r["id"]])
+
 
 class KernelWidthTests(SparkSessionTestCase):
 

--- a/sparkling_lime/tests/test_metrics.py
+++ b/sparkling_lime/tests/test_metrics.py
@@ -24,16 +24,16 @@ class PairwiseDistanceTests(SparkSessionTestCase):
         with self.subTest("Test default parameters exist"):
             d0 = metrics.PairwiseDistance()
             self.assertCountEqual(
-                d0.params, [d0.inputCol, d0.outputCol, d0.metric, d0.rowVector])
+                d0.params, [d0.inputCol, d0.outputCol, d0.distanceMetric, d0.rowVector])
             self.assertTrue(all([~d0.isSet(p) for p in d0.params]))
-            self.assertTrue(d0.hasDefault(d0.metric))
-            self.assertEqual(d0.getMetric(), "euclidean")
+            self.assertTrue(d0.hasDefault(d0.distanceMetric))
+            self.assertEqual(d0.getDistanceMetric(), "euclidean")
 
         with self.subTest("Test parameters are set"):
             d0.setParams(inputCol="input", outputCol="output", rowVector=vec,
-                         metric="euclidean")
+                         distanceMetric="euclidean")
             self.assertTrue(all([d0.isSet(p) for p in d0.params]))
-            self.assertEqual(d0.getMetric(), "euclidean")
+            self.assertEqual(d0.getDistanceMetric(), "euclidean")
             self.assertEqual(d0.getRowVector(), vec)
             self.assertEqual(d0.getInputCol(), "input")
             self.assertEqual(d0.getOutputCol(), "output")
@@ -48,9 +48,9 @@ class PairwiseDistanceTests(SparkSessionTestCase):
                           "distinct"):
             d1 = metrics.PairwiseDistance(
                 rowVector=vec, inputCol="features", outputCol="output",
-                metric="euclidean")
+                distanceMetric="euclidean")
             self.assertNotEqual(d1.uid, d0.uid)
-            self.assertEqual(d1.getMetric(), "euclidean")
+            self.assertEqual(d1.getDistanceMetric(), "euclidean")
             self.assertEqual(d1.getRowVector(), vec)
             self.assertEqual(d1.getInputCol(), "features")
             self.assertEqual(d1.getOutputCol(), "output")

--- a/target/.history
+++ b/target/.history
@@ -1,0 +1,2 @@
+import spark.implicits_
+exit


### PR DESCRIPTION
Adds a Pipeline compatible method to learn linear models on an array of datasets serially or in parallel.
-----
This PR introduces LocalLinearLearner, which is mostly just a wrapper around a LinearRegression that enables it to train many LinearRegression models in parallel.

Imagine an array of datasets, each containing a single customer's data. We want to train a model on each dataset in the array. Since that is time consuming, I added some methods to do train models in parallel. The output of that is an array of fitted Linear Regression models, where each model is associated with each dataset. When a `LocalLinearLearner` is `fit` on an array of datasets, it generates a `LocalLinearLearnerModel`, with the array of fitted Linear Regression models stored in the `fittedModels` property.

Finally, we want to generate predictions on each dataset in the array, and get information about each model (such as the intercept and coefficients, or feature weights). I have also parallelized this process in `LocalLinearLearnerModel`. The output of calling `transform` on an array of datasets is the same array of datasets, but each now with additional columns that contain the relevant information we want (prediction, intercept, coefficients, etc.).